### PR TITLE
docs: add more README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 Go client for Casbin Server
 ====
+[![Go Report Card](https://goreportcard.com/badge/github.com/casbin/casbin-go-client)](https://goreportcard.com/report/github.com/casbin/casbin-go-client)
 [![ci](https://img.shields.io/github/workflow/status/casbin/casbin-go-client/CI)](https://github.com/casbin/casbin-go-client/actions)
 [![Go Reference](https://pkg.go.dev/badge/github.com/casbin/casbin-go-client.svg)](https://pkg.go.dev/github.com/casbin/casbin-go-client)
+[![Release](https://img.shields.io/github/release/casbin/casbin-go-client.svg)](https://github.com/casbin/casbin-go-client/releases/latest)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/casbin/lobby)
+[![Sourcegraph](https://sourcegraph.com/github.com/casbin/casbin-go-client/-/badge.svg)](https://sourcegraph.com/github.com/casbin/casbin-go-client?badge)
 
 ``casbin-go-client`` is Golang's client for [Casbin-Server](https://github.com/casbin/casbin-server). ``Casbin-Server`` is the ``Access Control as a Service (ACaaS)`` solution based on [Casbin](https://github.com/casbin/casbin).
 


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-go-client/issues/18

All the badges were added as in https://github.com/casbin/casbin except coverage status.

- [x] Go Report Card
- [x] Build Status (existing)
- [ ] Coverage Status
- [x] Godoc (existing)
- [x] Release
- [x] Gitter
- [x] Sourcegraph

Coverage Status require me to be a member/owner of the project/organization to be able to add the repo. I am skipping that for now. It'd be great if someone can set that up for me.