### PR TITLE
fix: avoid panic on server exception

### DIFF
--- a/client/enforce.go
+++ b/client/enforce.go
@@ -93,6 +93,9 @@ func (e *Enforcer) Enforce(ctx context.Context, params ...interface{}) (bool, er
 		EnforcerHandler: e.handler,
 		Params:          data,
 	})
+	if err != nil {
+		return false, err
+	}
 	return res.Res, err
 }
 

--- a/client/enforce_test.go
+++ b/client/enforce_test.go
@@ -43,7 +43,7 @@ func testGetPolicy(t *testing.T, myRes, res [][]string) {
 func testAddPolicy(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	_, err := e.AddPolicy(ctx, "alice", "data1", "read" )
+	_, err := e.AddPolicy(ctx, "alice", "data1", "read")
 	if err != nil {
 		t.Fatalf("GetPolicy err: %v", err)
 	}
@@ -63,7 +63,7 @@ func testAddPolicy(t *testing.T) {
 func testRemovePolicy(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	_,err := e.RemovePolicy(ctx,"alice","data1","read")
+	_, err := e.RemovePolicy(ctx, "alice", "data1", "read")
 	if err != nil {
 		t.Fatalf("Remove err: %v", err)
 	}
@@ -75,13 +75,30 @@ func testRemovePolicy(t *testing.T) {
 		t.Fatalf("GetPolicy err: %v", err)
 	}
 
-	testGetPolicy(t, policies, [][]string{
-	})
+	testGetPolicy(t, policies, [][]string{})
+}
+
+func testEnforce(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := e.Enforce(ctx, "alice")
+	if err == nil {
+		t.Fatalf("Not found error: invalid request size")
+	}
+
+	res, err := e.Enforce(ctx, "alice", "data1", "read")
+	if err != nil {
+		t.Fatalf("Remove err: %v", err)
+	}
+	if !res {
+		t.Fatalf("Matched policies")
+	}
 }
 
 func TestEnforcer(t *testing.T) {
 	testNewEnforcer(t)
 
 	testAddPolicy(t)
+	testEnforce(t)
 	testRemovePolicy(t)
 }


### PR DESCRIPTION
If the server sends an exception in the enforce method, client panics
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x150ab3f]

```
for example: if we send not enough parameters, the server sends
`Incorrect size of parameters rpc error: code = Unknown desc = invalid request size: expected 3, got 1, rvals:`