### PR TITLE
feat: upgrade CI Node.js version to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
@@ -34,14 +34,14 @@ jobs:
       run: go test ./...
 
   semantic-release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
     
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.8.1'
+          node-version: 20
     
       - name: Run semantic-release
         if: github.repository == 'casbin/casbin-go-client' && github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+    
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.8.1'
+    
       - name: Run semantic-release
         if: github.repository == 'casbin/casbin-go-client' && github.event_name == 'push'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
 
@@ -34,7 +34,7 @@ jobs:
       run: go test ./...
 
   semantic-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
     


### PR DESCRIPTION
Fix: #25

Added a new step to setup the Node version to "20.8.1" and Also specified Ubuntu version to prevent same version conflicts in the future 

Changes:
- Added setup Node version step in ".github/workflows/ci.yml" file to use Node version "20.8.1"
- Specified Ubuntu version in "runs-on" steps